### PR TITLE
Resolve pypandoc convert() deprectation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 from setuptools import setup
 
-import pypandoc
-
 try:
     import pypandoc
     long_description = pypandoc.convert_file('README.md', 'rst')

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 from setuptools import setup
 
+import pypandoc
+
 try:
     import pypandoc
-    long_description = pypandoc.convert('README.md', 'rst')
+    long_description = pypandoc.convert_file('README.md', 'rst')
 except(IOError, ImportError):
     long_description = open('README.md').read()
 


### PR DESCRIPTION
Resolves:

```
setup.py:5: DeprecationWarning: Due to possible ambiguity, 'convert()' is deprecated and will be removed in pypandoc 1.8. Use 'convert_file()'  or 'convert_text()'.
  long_description = pypandoc.convert('README.md', 'rst')
```